### PR TITLE
[Fix] Remove `@context_for_validation` 

### DIFF
--- a/lib/schema_dot_org.rb
+++ b/lib/schema_dot_org.rb
@@ -98,7 +98,7 @@ module SchemaDotOrg
 
 
     def attrs
-      instance_variables.reject{ |v| [:@validation_context, :@errors].include?(v) }
+      instance_variables.reject{ |v| %i[@context_for_validation@validation_context @errors].include?(v) }
     end
 
 

--- a/lib/schema_dot_org.rb
+++ b/lib/schema_dot_org.rb
@@ -98,7 +98,7 @@ module SchemaDotOrg
 
 
     def attrs
-      instance_variables.reject{ |v| %i[@context_for_validation@validation_context @errors].include?(v) }
+      instance_variables.reject{ |v| [:@context_for_validation, :@validation_context, :@errors].include?(v) }
     end
 
 


### PR DESCRIPTION
Removes the `contextForValidation` from the attributes hash.